### PR TITLE
added guard + behavior to raise an exception for LEB128 decoding

### DIFF
--- a/lib/varint/leb128.ex
+++ b/lib/varint/leb128.ex
@@ -44,7 +44,7 @@ defmodule Varint.LEB128 do
 
   """
   @spec decode(binary) :: {non_neg_integer, binary}
-  def decode(b), do: do_decode(0, 0, b)
+  def decode(b) when is_binary(b), do: do_decode(0, 0, b)
 
 
   # -- Private
@@ -60,6 +60,10 @@ defmodule Varint.LEB128 do
       shift + 7,
       rest
     )
+  end
+
+  defp do_decode(_result, _shift, _bin) do
+    raise ArgumentError, "not a valid LEB128 encoded integer"
   end
 
 end

--- a/test/varint/leb128_test.exs
+++ b/test/varint/leb128_test.exs
@@ -1,6 +1,6 @@
 defmodule Varint.LEB128Test do
 
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest Varint.LEB128
 
   test "Symmetric" do
@@ -8,6 +8,10 @@ defmodule Varint.LEB128Test do
     fn x ->
       assert (x |> Varint.LEB128.encode() |> Varint.LEB128.decode()) == {x, <<>>}
     end)
+  end
+
+  test "Decode raises an error for non-LEB128 encoded data" do
+    assert_raise ArgumentError, fn -> Varint.LEB128.decode(<<255>>) end
   end
 
 end


### PR DESCRIPTION
I've added an exception that gets raised when the input data for LEB128 decoding is invalid. I've encountered this when working with some external varint sources that use LEB128, but sometimes have bad data. This behavior is consistent with the core Elixir `Base` library.

The previous behavior was a ClauseError which is much less clear. I added a guard to at least produce that when someone isn't calling the function correctly to differentiate between a bad binary vs an erroneous argument.

I've also added a test and not changed the interface. Thanks.