### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ iex> Varint.LEB128.decode(<<172, 2>>)
 
 ### Zigzag
 
-As LEB128 works with unsigned integers, you can use the the Zigzag module to process signed integers.
+As LEB128 works with unsigned integers, you can use the Zigzag module to process signed integers.
 
 ```elixir
 iex> Varint.Zigzag.encode(-2)


### PR DESCRIPTION
## Summary
- fix a duplicated word in README documentation

## Testing
- `mix test` *(fails: dependencies are missing)*

------
https://chatgpt.com/codex/tasks/task_e_688cbc32984c8329b1db83bb144e4554