### PR TITLE
Extend invalid decode test

### DIFF
--- a/test/varint/leb128_test.exs
+++ b/test/varint/leb128_test.exs
@@ -83,5 +83,6 @@ defmodule Varint.LEB128Test do
 
   test "Decode raises an error for non-LEB128 encoded data" do
     assert_raise ArgumentError, fn -> Varint.LEB128.decode(<<255>>) end
+    assert_raise ArgumentError, fn -> Varint.LEB128.decode(<<128>>) end
   end
 end


### PR DESCRIPTION
## Summary
- extend invalid LEB128 decode test with missing continuation byte

## Testing
- `mix test` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_688cbe9a9df88329a2bceea0d28c42d5