### PR TITLE
Add SLEB128 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Add SLEB128 encoding and decoding for signed integers.
+
 ## [1.5.1]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ iex> Varint.LEB128.decode(<<172, 2>>)
 {300, <<>>}
 ```
 
+### SLEB128
+
+Use this module to compress and decompress signed integers using signed LEB128:
+
+```elixir
+iex> Varint.SLEB128.encode(-624485)
+<<155, 241, 89>>
+```
+
+```elixir
+iex> Varint.SLEB128.decode(<<155, 241, 89>>)
+{-624485, <<>>}
+```
+
 ### Zigzag
 
 As LEB128 works with unsigned integers, you can use the Zigzag module to process signed integers.

--- a/lib/varint/sleb128.ex
+++ b/lib/varint/sleb128.ex
@@ -1,0 +1,130 @@
+defmodule Varint.SLEB128 do
+  @moduledoc """
+  This module provides functions to convert signed integers to and from SLEB128 encoded integers.
+
+      iex> Varint.SLEB128.encode(-624485)
+      <<155, 241, 89>>
+
+      iex> Varint.SLEB128.decode(<<155, 241, 89>>)
+      {-624485, <<>>}
+  """
+
+  import Bitwise
+
+  @doc """
+    Encodes a signed integer using SLEB128 compression.
+
+      iex> Varint.SLEB128.encode(0)
+      <<0>>
+
+      iex> Varint.SLEB128.encode(1)
+      <<1>>
+
+      iex> Varint.SLEB128.encode(-1)
+      <<127>>
+
+      iex> Varint.SLEB128.encode(624485)
+      <<229, 142, 38>>
+  """
+  @spec encode(integer) :: binary
+  def encode(v) when v >= -(1 <<< 6) and v < 1 <<< 6,
+    do: <<v &&& 0x7F>>
+
+  def encode(v) when v >= -(1 <<< 13) and v < 1 <<< 13,
+    do: <<(v &&& 0x7F) ||| 0x80, v >>> 7 &&& 0x7F>>
+
+  def encode(v) when v >= -(1 <<< 20) and v < 1 <<< 20,
+    do: <<(v &&& 0x7F) ||| 0x80, (v >>> 7 &&& 0x7F) ||| 0x80, v >>> 14 &&& 0x7F>>
+
+  def encode(v) when v >= -(1 <<< 27) and v < 1 <<< 27,
+    do:
+      <<(v &&& 0x7F) ||| 0x80, (v >>> 7 &&& 0x7F) ||| 0x80, (v >>> 14 &&& 0x7F) ||| 0x80,
+        v >>> 21 &&& 0x7F>>
+
+  def encode(v) when v >= -(1 <<< 34) and v < 1 <<< 34,
+    do:
+      <<(v &&& 0x7F) ||| 0x80, (v >>> 7 &&& 0x7F) ||| 0x80, (v >>> 14 &&& 0x7F) ||| 0x80,
+        (v >>> 21 &&& 0x7F) ||| 0x80, v >>> 28 &&& 0x7F>>
+
+  def encode(v) when v >= -(1 <<< 41) and v < 1 <<< 41,
+    do:
+      <<(v &&& 0x7F) ||| 0x80, (v >>> 7 &&& 0x7F) ||| 0x80, (v >>> 14 &&& 0x7F) ||| 0x80,
+        (v >>> 21 &&& 0x7F) ||| 0x80, (v >>> 28 &&& 0x7F) ||| 0x80, v >>> 35 &&& 0x7F>>
+
+  def encode(v) when v >= -(1 <<< 48) and v < 1 <<< 48,
+    do:
+      <<(v &&& 0x7F) ||| 0x80, (v >>> 7 &&& 0x7F) ||| 0x80, (v >>> 14 &&& 0x7F) ||| 0x80,
+        (v >>> 21 &&& 0x7F) ||| 0x80, (v >>> 28 &&& 0x7F) ||| 0x80, (v >>> 35 &&& 0x7F) ||| 0x80,
+        v >>> 42 &&& 0x7F>>
+
+  def encode(v) when v >= -(1 <<< 55) and v < 1 <<< 55,
+    do:
+      <<(v &&& 0x7F) ||| 0x80, (v >>> 7 &&& 0x7F) ||| 0x80, (v >>> 14 &&& 0x7F) ||| 0x80,
+        (v >>> 21 &&& 0x7F) ||| 0x80, (v >>> 28 &&& 0x7F) ||| 0x80, (v >>> 35 &&& 0x7F) ||| 0x80,
+        (v >>> 42 &&& 0x7F) ||| 0x80, v >>> 49 &&& 0x7F>>
+
+  def encode(v) when is_integer(v), do: do_encode(v, [])
+
+  @doc """
+    Decodes SLEB128 encoded bytes to a signed integer.
+
+    Returns a tuple where the first element is the decoded value and the second
+    element the bytes which have not been parsed.
+
+    This function will raise `ArgumentError` if the given `b` is not a valid SLEB128 integer.
+
+      iex> Varint.SLEB128.decode(<<229, 142, 38>>)
+      {624485, <<>>}
+
+      iex> Varint.SLEB128.decode(<<229, 142, 38, 0>>)
+      {624485, <<0>>}
+
+      iex> Varint.SLEB128.decode(<<0>>)
+      {0, <<>>}
+
+      iex> Varint.SLEB128.decode(<<127>>)
+      {-1, <<>>}
+
+      iex> Varint.SLEB128.decode(<<128>>)
+      ** (ArgumentError) not a valid SLEB128 encoded integer
+  """
+  @spec decode(binary) :: {integer, binary}
+  def decode(b), do: do_decode(0, 0, b)
+
+  # -- Private
+
+  @spec do_encode(integer, iodata) :: binary
+  defp do_encode(v, acc) do
+    byte = v &&& 0x7F
+    next = v >>> 7
+    sign_set = (byte &&& 0x40) != 0
+    done = (next == 0 and not sign_set) or (next == -1 and sign_set)
+    byte = if done, do: byte, else: byte ||| 0x80
+    acc = [acc, <<byte>>]
+
+    if done do
+      IO.iodata_to_binary(acc)
+    else
+      do_encode(next, acc)
+    end
+  end
+
+  @spec do_decode(integer, non_neg_integer, binary) :: {integer, binary}
+  defp do_decode(result, shift, <<0::1, byte::7, rest::binary>>) do
+    result = result ||| byte <<< shift
+
+    if (byte &&& 0x40) == 0 do
+      {result, rest}
+    else
+      {result ||| -1 <<< (shift + 7), rest}
+    end
+  end
+
+  defp do_decode(result, shift, <<1::1, byte::7, rest::binary>>) do
+    do_decode(result ||| byte <<< shift, shift + 7, rest)
+  end
+
+  defp do_decode(_result, _shift, _bin) do
+    raise ArgumentError, "not a valid SLEB128 encoded integer"
+  end
+end

--- a/test/varint/sleb128_test.exs
+++ b/test/varint/sleb128_test.exs
@@ -1,0 +1,90 @@
+defmodule SLEB128Simple do
+  import Bitwise
+
+  @spec encode(integer) :: binary()
+  def encode(v), do: do_encode(v, [])
+
+  @spec decode(binary) :: {integer, binary}
+  def decode(b), do: do_decode(0, 0, b)
+
+  defp do_encode(v, acc) do
+    byte = v &&& 0x7F
+    next = v >>> 7
+    sign_set = (byte &&& 0x40) != 0
+    done = (next == 0 and not sign_set) or (next == -1 and sign_set)
+    byte = if done, do: byte, else: byte ||| 0x80
+    acc = [acc, <<byte>>]
+
+    if done do
+      IO.iodata_to_binary(acc)
+    else
+      do_encode(next, acc)
+    end
+  end
+
+  defp do_decode(result, shift, <<0::1, byte::7, rest::binary>>) do
+    result = result ||| byte <<< shift
+
+    if (byte &&& 0x40) == 0 do
+      {result, rest}
+    else
+      {result ||| -1 <<< (shift + 7), rest}
+    end
+  end
+
+  defp do_decode(result, shift, <<1::1, byte::7, rest::binary>>) do
+    do_decode(result ||| byte <<< shift, shift + 7, rest)
+  end
+end
+
+defmodule Varint.SLEB128Test do
+  import Bitwise
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  doctest Varint.SLEB128
+
+  property "Encoding produces the same result as the reference implementation" do
+    check all int <- integer(-(1 <<< 63)..(1 <<< 63)) do
+      assert Varint.SLEB128.encode(int) == SLEB128Simple.encode(int)
+    end
+  end
+
+  property "Decoding produces the same result as the reference implementation" do
+    check all int <- integer(-(1 <<< 63)..(1 <<< 63)) do
+      encoded = SLEB128Simple.encode(int)
+      assert Varint.SLEB128.decode(encoded) == SLEB128Simple.decode(encoded)
+    end
+  end
+
+  property "Symmetric" do
+    check all int <- integer(-(1 <<< 63)..(1 <<< 63)) do
+      assert int |> Varint.SLEB128.encode() |> Varint.SLEB128.decode() == {int, ""}
+    end
+  end
+
+  test "Encode" do
+    assert Varint.SLEB128.encode(0) == <<0>>
+    assert Varint.SLEB128.encode(1) == <<1>>
+    assert Varint.SLEB128.encode(-1) == <<0x7F>>
+    assert Varint.SLEB128.encode(63) == <<0x3F>>
+    assert Varint.SLEB128.encode(64) == <<0xC0, 0x00>>
+    assert Varint.SLEB128.encode(-64) == <<0x40>>
+    assert Varint.SLEB128.encode(-65) == <<0xBF, 0x7F>>
+    assert Varint.SLEB128.encode(624_485) == <<0xE5, 0x8E, 0x26>>
+    assert Varint.SLEB128.encode(-624_485) == <<0x9B, 0xF1, 0x59>>
+  end
+
+  test "Decode" do
+    assert Varint.SLEB128.decode(<<0>>) == {0, ""}
+    assert Varint.SLEB128.decode(<<0x7F>>) == {-1, ""}
+    assert Varint.SLEB128.decode(<<0xE5, 0x8E, 0x26>>) == {624_485, ""}
+    assert Varint.SLEB128.decode(<<0x9B, 0xF1, 0x59>>) == {-624_485, ""}
+    assert Varint.SLEB128.decode(<<0x9B, 0xF1, 0x59, 0>>) == {-624_485, <<0>>}
+  end
+
+  test "Decode raises an error for non-SLEB128 encoded data" do
+    assert_raise ArgumentError, fn -> Varint.SLEB128.decode(<<255>>) end
+    assert_raise ArgumentError, fn -> Varint.SLEB128.decode(<<128>>) end
+  end
+end


### PR DESCRIPTION
## Summary

- add `Varint.SLEB128` for signed LEB128 encoding and decoding
- document SLEB128 usage alongside LEB128 and Zigzag
- cover examples, round-trips, and reference implementation properties